### PR TITLE
Release 3.8.0

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,7 +6,8 @@
 
     <application
         android:name="com.example.mediquosdktest.App"
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:fullBackupOnly="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,7 @@ composeBom = "2025.10.01"
 googleServices = "4.4.2"
 hiltVersion = "2.54"
 kspVersion = "2.2.0-2.0.2"
-mediquoSdk = "3.7.8"
+mediquoSdk = "3.8.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
PREVIOUS SIZE:
<img width="1298" height="389" alt="Captura de pantalla 2026-03-02 a las 13 09 34" src="https://github.com/user-attachments/assets/35f6e1b7-d1bd-4efd-9488-b012f24f88b6" />

NEW SIZE:
<img width="1297" height="385" alt="Captura de pantalla 2026-03-02 a las 13 06 27" src="https://github.com/user-attachments/assets/409ee920-7fed-421a-bf2a-db360e5d5f98" />

